### PR TITLE
Custom container listening scroll events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-parallaxy",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Vue 2 component for parallax scrolling effects",
   "author": "Jakub Juszczak <jakub@posteo.de>",
   "license": "MIT",
@@ -99,5 +99,8 @@
   "engines": {
     "node": ">= 4.0.0",
     "npm": ">= 3.0.0"
+  },
+  "dependencies": {
+    "yarn": "^1.10.1"
   }
 }

--- a/src/components/Parallax.vue
+++ b/src/components/Parallax.vue
@@ -52,13 +52,19 @@
       direction: {
         type: String,
         default: 'up'
+      },
+      customWrapperReference: {
+        type: String,
+        default: '',
+        required: false
       }
     },
 
     data () {
       return {
         el: null,
-        mediaQuery: null
+        mediaQuery: null,
+        scrollWrapper: null
       }
     },
 
@@ -81,7 +87,13 @@
         const parentHeight = this.$refs.block.offsetHeight
         const parallaxHeight = this.$refs.parallax.offsetHeight
         const availableOffset = parallaxHeight - parentHeight
-        let animationValue = (window.pageYOffset * this.speedFactor)
+        let animationValue
+
+        if (this.customWrapperReference) {
+          animationValue = (this.scrollWrapper.scrollTop * this.speedFactor)
+        } else {
+          animationValue = (this.scrollWrapper.pageYOffset * this.speedFactor)
+        }
 
         if (animationValue <= availableOffset && animationValue >= 0) {
           this.el.style.transform = `translate3d(0, ${animationValue * this.directionValue}px ,0)`
@@ -101,20 +113,26 @@
 
         return (
           rect.bottom >= 0 &&
-          rect.top <= (window.innerHeight || document.documentElement.clientHeight)
+          rect.top <= (this.scrollWrapper.innerHeight || document.documentElement.clientHeight)
         )
       },
 
       setupListener () {
         if (this.mediaQuery.matches) {
-          window.addEventListener('scroll', this.scrollHandler, false)
+          this.scrollWrapper.addEventListener('scroll', this.scrollHandler, false)
         } else {
-          window.removeEventListener('scroll', this.scrollHandler, false)
+          this.scrollWrapper.removeEventListener('scroll', this.scrollHandler, false)
         }
       },
 
       init () {
         this.mediaQuery = window.matchMedia(this.breakpoint)
+
+        if (this.customWrapperReference) {
+          this.scrollWrapper = document.querySelector(this.customWrapperReference)
+        } else {
+          this.scrollWrapper = window
+        }
 
         if (this.mediaQuery) {
           this.mediaQuery.addListener(this.setupListener)
@@ -124,7 +142,7 @@
     },
 
     beforeDestroy () {
-      window.removeEventListener('scroll', this.scrollHandler, false)
+      this.scrollWrapper.removeEventListener('scroll', this.scrollHandler, false)
     },
 
     computed: {


### PR DESCRIPTION
## Description
Vue-parallax only attaches events to the window element itself which works fine for some cases, but if the user needs a custom container overflowing instead of the default window the `translate` movement does not get applied to the image container.

This feature allows a new prop to be passed to the component, `customWrapperReference` which is a string reference to an HTML element container (id, class). The scroll event is applied/destroyed to this container instead of the window.

## Fix or Feature?
Feature

### Environment
- OS: OS X Mojave
- NPM Version: 5.6.0

